### PR TITLE
Manually run prepare_dp_attn_batch() without scheduler, in bench_one_…

### DIFF
--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -232,6 +232,16 @@ def extend(reqs, model_runner):
         enable_custom_logit_processor=False,
     )
     batch.prepare_for_extend()
+
+    if model_runner.server_args.enable_dp_attention:
+        # Need to call prepare_dp_attn_batch(), but there is no Scheduler in batch_one_batch.
+        # Modified from prepare_dp_attn_batch().
+        # In extend(), thus in extend mode.
+        num_tokens = batch.extend_num_tokens
+
+        batch.global_num_tokens = [num_tokens] * model_runner.server_args.dp_size
+        batch.can_run_dp_cuda_graph = True
+
     model_worker_batch = batch.get_model_worker_batch()
     forward_batch = ForwardBatch.init_new(model_worker_batch, model_runner)
     logits_output = model_runner.forward(forward_batch)
@@ -243,6 +253,16 @@ def extend(reqs, model_runner):
 def decode(input_token_ids, batch, model_runner):
     batch.output_ids = input_token_ids
     batch.prepare_for_decode()
+
+    if model_runner.server_args.enable_dp_attention:
+        # Need to call prepare_dp_attn_batch(), but there is no Scheduler in batch_one_batch.
+        # Modified from prepare_dp_attn_batch().
+        # In decode(), batch.forward_mode.is_decode() is True.
+        num_tokens = batch.batch_size()
+
+        batch.global_num_tokens = [num_tokens] * model_runner.server_args.dp_size
+        batch.can_run_dp_cuda_graph = True
+
     model_worker_batch = batch.get_model_worker_batch()
     forward_batch = ForwardBatch.init_new(model_worker_batch, model_runner)
     logits_output = model_runner.forward(forward_batch)


### PR DESCRIPTION
With DP attention (--enable-dp-attention), all_gather() in deepseek_v2.py requires the batch to have a attribute global_num_tokens. global_num_tokens is updated in prepare_dp_attn_batch() with Scheduler class in scheduler.py. However, in bench_one_batch.py, there is no Scheduler and bench_one_batch would crash due to missing global_num_tokens. Manually set global_num_tokens. 

`python3 -m sglang.bench_one_batch --model-path /checkpoints/deepseek-lite --trust-remote-code --batch 8 --disable-radix-cache  --tp 8 --enable-ep-moe --enable-dp-attention`

## Checklist

- [ X] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ X] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ X] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ X] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html).
